### PR TITLE
Update README.md to emphasis the import in the MAIN module

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Import `NgxTippyModule`:
 import { NgxTippyModule } from 'ngx-tippy-wrapper';
 ```
 
-Then in your base module:
+Then in your main module:
 
 ```ts
 @NgModule({


### PR DESCRIPTION
I think that it is confusing, to call the `main` module `base` module. For instance: in my case I had a complex module-tree, and the "base" in my understanding it the place where I want to use the library. Doing so without importing the lib in the main module will produce an error, see https://github.com/farengeyt451/ngx-tippy-wrapper/issues/31