### PR TITLE
Fix the projection of tippyName when using ng-template 

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ export class DemoComponent implements OnInit {
 | `tippyProps`     | NgxTippyProps | [tippyProps]="{ arrow: false, placement: 'bottom' }"                               |
 | `tippyName`      | string        | tippyName="awesomeName"                                                            |
 | `tippyClassName` | string        | tippyClassName="new-class" <br> _or_ <br> tippyClassName="new-class another-class" |
-| `tippyContext`   | any           | [tippyContext]="{ aKey: 'something' }" |
+| `tippyContext`   | NgxTippyContext           | [tippyContext]="{ aKey: 'something' }" |
 
 `tippyProps` - [list of all props](https://atomiks.github.io/tippyjs/v6/all-props/)
 

--- a/README.md
+++ b/README.md
@@ -150,12 +150,15 @@ export class DemoComponent implements OnInit {
 | `tippyProps`     | NgxTippyProps | [tippyProps]="{ arrow: false, placement: 'bottom' }"                               |
 | `tippyName`      | string        | tippyName="awesomeName"                                                            |
 | `tippyClassName` | string        | tippyClassName="new-class" <br> _or_ <br> tippyClassName="new-class another-class" |
+| `tippyContext`   | any           | [tippyContext]="{ aKey: 'something' }" |
 
 `tippyProps` - [list of all props](https://atomiks.github.io/tippyjs/v6/all-props/)
 
 `tippyName` - name for tippy instance, required for accessing and control specific instance
 
 `tippyClassName` - add custom class to the `tippy-box` element, support multiple classes passed as words separated by space
+
+`tippyContext` - A way to bind any context you want to the template when using `ng-template`
 
 ### Initializing on condition
 
@@ -319,14 +322,15 @@ export class DemoComponent implements OnInit {
 6. **`ng-template`**:
 
 ```html
-<button [ngxTippy]="tooltipTemplate">Element with tooltip</button>
+<button [ngxTippy]="tooltipTemplate" [tippyContext]="{ item: { name: 'test' }}">Element with tooltip</button>
 
 <ng-template
   #tooltipTemplate
   let-name
+  let-item="item"
 >
   {{ name | json }}
-  <h2>Content via ng-template</h2>
+  <h2>Content via ng-template, item's name = {{ item.name }}</h2>
 </ng-template>
 ```
 

--- a/projects/ngx-tippy-demo/src/app/app.component.html
+++ b/projects/ngx-tippy-demo/src/app/app.component.html
@@ -355,7 +355,7 @@
         tippyName="ng-template-ref-plus-context"
         [ngxTippy]="tplctx"
         [tippyProps]="ngTemplateRef"
-        [tippyContext]="{ foo: 'bar' }"
+        [tippyContext]="templateContext"
       >
         Element with tooltip
       </button>
@@ -366,15 +366,7 @@
         let-foo="foo"
       >
         <div class="t-template">
-          <h4 class="t-template__caption">Caption</h4>
-          <p class="t-template__info">Some content</p>
-          <span class="t-template__name">Passed tippyName {{ name }} and context foo = {{ foo }}</span>
-          <button
-            class="t-demo__btn"
-            (focus)="tippyService.hide(name)"
-          >
-            Close (focus)
-          </button>
+          <span class="t-template__name">Passed tippyName <b>{{ name }}</b> and context <b>{{ foo }}</b></span>
         </div>
       </ng-template>
     </div>

--- a/projects/ngx-tippy-demo/src/app/app.component.html
+++ b/projects/ngx-tippy-demo/src/app/app.component.html
@@ -342,6 +342,41 @@
           </button>
         </div>
       </ng-template>
+
+      <!-- Example block -->
+      <p class="t-demo__text">
+        Applying content passing
+        <span class="t-demo__highlighted">ng-template ref with context</span>
+      </p>
+
+      <button
+        class="t-demo__btn"
+        ngxTippy
+        tippyName="ng-template-ref-plus-context"
+        [ngxTippy]="tplctx"
+        [tippyProps]="ngTemplateRef"
+        [tippyContext]="{ foo: 'bar' }"
+      >
+        Element with tooltip
+      </button>
+
+      <ng-template
+        #tplctx
+        let-name
+        let-foo="foo"
+      >
+        <div class="t-template">
+          <h4 class="t-template__caption">Caption</h4>
+          <p class="t-template__info">Some content</p>
+          <span class="t-template__name">Passed tippyName {{ name }} and context foo = {{ foo }}</span>
+          <button
+            class="t-demo__btn"
+            (focus)="tippyService.hide(name)"
+          >
+            Close (focus)
+          </button>
+        </div>
+      </ng-template>
     </div>
 
     <div class="t-demo__block">

--- a/projects/ngx-tippy-demo/src/app/app.component.ts
+++ b/projects/ngx-tippy-demo/src/app/app.component.ts
@@ -37,6 +37,10 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     theme: 'light',
   };
 
+  public templateContext = {
+    foo: 'bar'
+  }
+
   public fromComponent: NgxTippyProps = { ...this.baseProps, arrow: false, placement: 'bottom' };
 
   public binding: NgxTippyProps = { ...this.baseProps, content: this.boundContent };

--- a/projects/ngx-tippy-wrapper/src/lib/ngx-tippy.directive.ts
+++ b/projects/ngx-tippy-wrapper/src/lib/ngx-tippy.directive.ts
@@ -25,6 +25,7 @@ export class NgxTippyDirective implements OnInit, OnDestroy {
   @Input() tippyProps?: NgxTippyProps;
   @Input() tippyName?: string;
   @Input() tippyClassName?: string;
+  @Input() tippyContext: any;
 
   private tippyInstance: NgxTippyInstance | undefined;
   private cachedInstances = new Map();
@@ -61,7 +62,7 @@ export class NgxTippyDirective implements OnInit, OnDestroy {
 
     if (this.ngxTippy === null || this.ngxTippy === undefined) return;
 
-    const viewRef = this.ngxViewService.getViewRefInstance(this.ngxTippy, this.tippyName);
+    const viewRef = this.ngxViewService.getViewRefInstance(this.ngxTippy, this.tippyName, this.tippyContext);
     const tippyElement = viewRef.getElement();
 
     const tInstance = tippy(tippyTarget, {

--- a/projects/ngx-tippy-wrapper/src/lib/ngx-tippy.directive.ts
+++ b/projects/ngx-tippy-wrapper/src/lib/ngx-tippy.directive.ts
@@ -13,7 +13,7 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import tippy from 'tippy.js';
-import { NgxTippyContent, NgxTippyInstance, NgxTippyProps, TippyHTMLElement, ViewRef } from './ngx-tippy.interfaces';
+import { NgxTippyContent, NgxTippyContext, NgxTippyInstance, NgxTippyProps, TippyHTMLElement, ViewRef } from './ngx-tippy.interfaces';
 import { NgxTippyService, NgxViewService } from './services';
 import { setTemplateVisible } from './utils';
 
@@ -25,7 +25,7 @@ export class NgxTippyDirective implements OnInit, OnDestroy {
   @Input() tippyProps?: NgxTippyProps;
   @Input() tippyName?: string;
   @Input() tippyClassName?: string;
-  @Input() tippyContext: any;
+  @Input() tippyContext?: NgxTippyContext;
 
   private tippyInstance: NgxTippyInstance | undefined;
   private cachedInstances = new Map();
@@ -121,11 +121,12 @@ export class NgxTippyDirective implements OnInit, OnDestroy {
     tippyInstance && this.ngxTippyService.setInstance(tippyName, tippyInstance);
   }
 
-  private handleChanges({ tippyName, ngxTippy, tippyProps, tippyClassName }: SimpleChanges) {
+  private handleChanges({ tippyName, ngxTippy, tippyProps, tippyClassName, tippyContext }: SimpleChanges) {
     tippyName && !tippyName.firstChange && this.handleNameChanges(tippyName);
     ngxTippy && !ngxTippy.firstChange && this.handleContentChanges(ngxTippy);
     tippyProps && !tippyProps.firstChange && this.handlePropsChanges(tippyProps);
     tippyClassName && !tippyClassName.firstChange && this.handleClassChanges(tippyClassName);
+    tippyContext && !tippyContext.firstChange && this.handleContextChanges(tippyContext);
   }
 
   private handleNameChanges({ previousValue, currentValue }: SimpleChange) {
@@ -158,6 +159,14 @@ export class NgxTippyDirective implements OnInit, OnDestroy {
   private handleClassChanges({ previousValue, currentValue }: SimpleChange) {
     this.removeClassName(this.tippyInstance, previousValue);
     this.setClassName(this.tippyInstance, currentValue);
+  }
+
+  private handleContextChanges({ currentValue }: SimpleChange) {
+    if (this.tippyInstance && this.tippyName && this.ngxTippy) {
+      this.ngxTippyService.setContent(this.tippyName, this.ngxTippy, currentValue);
+    } else {
+      this.initTippy();
+    }
   }
 
   private cachedTippyInstances(): Map<string, NgxTippyInstance> | null {

--- a/projects/ngx-tippy-wrapper/src/lib/ngx-tippy.interfaces.ts
+++ b/projects/ngx-tippy-wrapper/src/lib/ngx-tippy.interfaces.ts
@@ -26,6 +26,8 @@ export type NgxTippyContent = NgxTippyTemplate | null | undefined;
 
 export type NgxTippyTemplate = Content | TemplateRef<any> | Type<any>;
 
+export type NgxTippyContext = Record<string, any>;
+
 export interface NgxTippyHideAllOptions {
   duration?: number;
   excludeName?: string;

--- a/projects/ngx-tippy-wrapper/src/lib/services/ngx-tippy.service.ts
+++ b/projects/ngx-tippy-wrapper/src/lib/services/ngx-tippy.service.ts
@@ -6,6 +6,7 @@ import {
   InstanceChangeReasonEnum,
   InstancesChanges,
   NgxTippyContent,
+  NgxTippyContext,
   NgxTippyDefaultProps,
   NgxTippyHideAllOptions,
   NgxTippyInstance,
@@ -191,7 +192,7 @@ export class NgxTippyService {
    * @param name { string } name of tippy instance
    * @param tippyContent { NgxTippyContent } new content
    */
-  setContent(name: string, tippyContent: NgxTippyContent) {
+  setContent(name: string, tippyContent: NgxTippyContent, tippyContext?: NgxTippyContext) {
     const instance = this.getInstance(name);
 
     if (!instance) {
@@ -200,7 +201,7 @@ export class NgxTippyService {
     }
 
     if (tippyContent) {
-      const viewRef = this.ngxViewService.getViewRefInstance(tippyContent, instance.tippyName);
+      const viewRef = this.ngxViewService.getViewRefInstance(tippyContent, instance.tippyName, tippyContext);
       const content = viewRef.getElement();
 
       if (content) {

--- a/projects/ngx-tippy-wrapper/src/lib/services/ngx-view.service.ts
+++ b/projects/ngx-tippy-wrapper/src/lib/services/ngx-view.service.ts
@@ -8,14 +8,13 @@ export class NgxViewService {
 
   constructor(private appRef: ApplicationRef) {}
 
-  getViewRefInstance(content: NgxTippyTemplate, tippyName?: string): ViewRef {
+  getViewRefInstance(content: NgxTippyTemplate, tippyName?: string, tippyContext?: any): ViewRef {
     let viewRef!: ViewRef;
 
     if (isTemplateRef(content)) {
       viewRef = this.createTemplate(content, {
-        context: {
-          $implicit: tippyName,
-        },
+        ...tippyContext,
+        $implicit: tippyName,
       });
     } else if (isComponent(content)) {
       viewRef = this.createComponent(content);

--- a/projects/ngx-tippy-wrapper/src/lib/services/ngx-view.service.ts
+++ b/projects/ngx-tippy-wrapper/src/lib/services/ngx-view.service.ts
@@ -1,5 +1,5 @@
 import { ApplicationRef, Injectable, TemplateRef, Type, ViewContainerRef } from '@angular/core';
-import { NgxTippyTemplate, ViewRef } from '../ngx-tippy.interfaces';
+import { NgxTippyContext, NgxTippyTemplate, ViewRef } from '../ngx-tippy.interfaces';
 import { CompRef, isComponent, isHTMLTemplate, isTemplateRef, TplRef } from '../utils';
 
 @Injectable({ providedIn: 'root' })
@@ -8,14 +8,12 @@ export class NgxViewService {
 
   constructor(private appRef: ApplicationRef) {}
 
-  getViewRefInstance(content: NgxTippyTemplate, tippyName?: string, tippyContext?: any): ViewRef {
+  getViewRefInstance(content: NgxTippyTemplate, tippyName?: string, tippyContext: NgxTippyContext = {}): ViewRef {
     let viewRef!: ViewRef;
 
     if (isTemplateRef(content)) {
-      viewRef = this.createTemplate(content, {
-        ...tippyContext,
-        $implicit: tippyName,
-      });
+      tippyContext.$implicit = tippyName
+      viewRef = this.createTemplate(content, tippyContext);
     } else if (isComponent(content)) {
       viewRef = this.createComponent(content);
     } else if (isHTMLTemplate(content)) {

--- a/projects/ngx-tippy-wrapper/src/unit-tests/ngx-view.service.spec.ts
+++ b/projects/ngx-tippy-wrapper/src/unit-tests/ngx-view.service.spec.ts
@@ -78,10 +78,12 @@ describe('Service: NgxViewService', () => {
     const ngTemplate = component.getNgTemplate();
 
     // Act
-    const vRef = viewService.getViewRefInstance(ngTemplate);
+    const vRef = viewService.getViewRefInstance(ngTemplate, 'test-name', { test: 'context' });
 
     // Assert
     expect(vRef).toBeInstanceOf(TplRef);
+    expect((vRef as any).viewRef.context.$implicit).toEqual('test-name');
+    expect((vRef as any).viewRef.context.test).toEqual('context');
   });
 
   it('should return component ref', () => {


### PR DESCRIPTION
This also adds [tippyContext] to pass a custom context to the template which solves #43